### PR TITLE
Escape "$" character in uri to solve bug

### DIFF
--- a/cortex
+++ b/cortex
@@ -283,6 +283,8 @@ def browseropen(uri):
             # Taken from webbrowser source since stderr is displayed using regular browser
             browser = webbrowser.get()
             if hasattr(browser, 'name'):
+                if "$" in uri:
+                    uri = uri.replace("$", "\$")
                 cmdline = browser.name + " " + uri
                 call( cmdline, shell=True, stdout=DEVNULL, stderr=DEVNULL)
             else:


### PR DESCRIPTION
This solves a bug I had with the following kind of url:

http://forum.dlang.org/thread/mca361$1no8$1@digitalmars.com

The "$1"s were removed resulting in incorrect url.

I decided to place that code as near as possible from the call to the
webbrowser that is made here as I am unsure about the possible side-effects.